### PR TITLE
Minor stylistic correction for consistency

### DIFF
--- a/src/components/CV/Research/Publications.vue
+++ b/src/components/CV/Research/Publications.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-.pad-tlr
+.pad-lr
   h4 Publications
   ul
     li


### PR DESCRIPTION
Other research tabs don't (and probably shouldn't) have top padding above their content, so this commit brings this tab into line with the other three